### PR TITLE
Fix #9 - Update broken Amazon Go imports

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"sync"
 
-	"launchpad.net/goamz/aws"
-	"launchpad.net/goamz/s3"
+	"gopkg.in/amz.v1/aws"
+	"gopkg.in/amz.v1/s3"
 )
 
 type Item struct {


### PR DESCRIPTION
Per Amazon's new Golang repo:  https://github.com/go-amz/amz/
`import "gopkg.in/amz.v1/<package>"`
From repo:  
`NOTE: This is a stable branch, which is compatible with the original goamz source from Launchpad, except for the changed import paths.`